### PR TITLE
fixed indexing issue, in model_AV_new.py

### DIFF
--- a/model/lib/model_AV_new.py
+++ b/model/lib/model_AV_new.py
@@ -20,7 +20,7 @@ def AV_model(people_num=2):
         return Lambda(lambda x: tf.image.resize_bilinear(x, size, align_corners=True))
 
     def sliced(x, index):
-        return x[:, :, :, index]
+        return x[..., index]
 
     # --------------------------- AS start ---------------------------
     audio_input = Input(shape=(298, 257, 2))


### PR DESCRIPTION
While slicing video input, we need to slice the last dimension i.e. `people_num`. During training the first dimension becomes the `batch_size`; hence slice [:, :, :, index] becomes wrong. This can be fixed using ellipsis. This error leads to incorrect model training because this will slice the embedding dimension and not the input face dimension.